### PR TITLE
Provide an example for a fully private cluster with Private Isolated Subnets and VPC Interface Endpoints

### DIFF
--- a/lib/ecs/cluster.ts
+++ b/lib/ecs/cluster.ts
@@ -17,9 +17,47 @@ export class EcsBlueGreenCluster extends Construct {
     constructor(scope: Construct, id: string, props: EcsBlueGreenClusterProps = {}) {
         super(scope, id);
 
+        // Create the VPC for the ECS cluster.  The VPC will have one private subnet without NAT Gateway.  
         this.vpc = new ec2.Vpc(this, 'ecsClusterVPC', {
-            cidr: props.cidr
-        });
+            cidr: props.cidr,
+            subnetConfiguration: [
+              {
+                name: 'Private',
+                subnetType: ec2.SubnetType.PRIVATE_ISOLATED              
+            }
+            ]  
+          });
+
+        // Create the VPC endpoint for the ECR registry
+        new ec2.InterfaceVpcEndpoint(this, 'ECRVpcEndpoint', {
+            vpc: this.vpc, 
+            service: ec2.InterfaceVpcEndpointAwsService.ECR,
+            privateDnsEnabled: true
+        })
+
+        // Create the VPC endpoint for the ECR Docker registry.  This is required for the Fargate task to pull the docker image from ECR.  
+        //This is not required for the ECS task to pull the docker image from ECR.  The ECS task will pull the docker image from EC
+
+        new ec2.InterfaceVpcEndpoint(this, 'ECRDockerVpcEndpoint', {
+            vpc: this.vpc,            
+            service: ec2.InterfaceVpcEndpointAwsService.ECR_DOCKER,
+            privateDnsEnabled: true
+        })
+
+        // access S3 bucket from Fargate task.  This is required for the Fargate task to pull the docker image from ECR.
+        new ec2.GatewayVpcEndpoint(this, 'S3GatewayEndpoint', {
+            service: ec2.GatewayVpcEndpointAwsService.S3,
+            vpc: this.vpc,            
+            subnets: [{ subnetType: ec2.SubnetType.PRIVATE_ISOLATED, }]
+        })
+        
+        // access Cloudwatch logging
+        new ec2.InterfaceVpcEndpoint(this, 'CloudWatchLogsVpcEndpoint', {
+            vpc: this.vpc,            
+            service: ec2.InterfaceVpcEndpointAwsService.CLOUDWATCH_LOGS,
+            privateDnsEnabled: true
+        })
+
         this.cluster = new ecs.Cluster(this, 'ecsCluster', {
             vpc: this.vpc,
             containerInsights: true

--- a/lib/ecs/service.ts
+++ b/lib/ecs/service.ts
@@ -59,7 +59,7 @@ export class EcsBlueGreenService extends Construct {
         // Creating an application load balancer, listener and two target groups for Blue/Green deployment
         this.alb = new albv2.ApplicationLoadBalancer(this, 'alb', {
             vpc: props.vpc!,
-            internetFacing: true
+            internetFacing: false
         });
         this.albProdListener = this.alb.addListener('albProdListener', {
             port: 80


### PR DESCRIPTION
Motivation:

I am a Support Engineer from AWS from the containers profile, and was helping a customer who was looking for an example of ECS Blue/Green in a cluster without Internet Gateway.
So I decided to provide an example to the customer by modifying this example.

Modified the file cluster.ts which creates the VPC Resources, and now it creates

  - VPC with only private subnets without NAT Gateway.
  - VPC Interface Endpoints to ECR, Docker and OCI client endpoints and Cloudwatch
  - VPC Gateway Endpoint for S3 
 This is to provide a fully private Cluster and access to the Service Endpoints internally.

  Also, I changed the ALB to be private by changing internetFacing variable to false on the attached file services.ts.

In case this PR is accepted, I would suggest creating a new branch called privatecluster and merge the changes on this PR This will provide customers with an example of ECS blue/green in a fully private cluster with Private Isolated Subnets and VPC Interface Endpoints on this repository.
We can also change README to explain there is another branch with example for deployment in a private cluster.

I have tested a deployment in the fully private cluster and it works successfully, please see attached.
![Screenshot 2023-12-04 at 5 00 34 pm](https://github.com/aws-containers/ecs-workshop-blue-green-deployments/assets/16223299/d4d819fc-5e20-4fd1-bd45-8d47a9394382)
